### PR TITLE
bump: golang 1.24.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         ports:
           - 5432:5432
     runs-on: "ubuntu-latest"
-    container: golang:1.23
+    container: golang:1.24
     env:
       DATABASE_HOST: postgres
       DATABASE_PORT: 5432

--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -4,7 +4,7 @@
 
 
 # https://catalog.redhat.com/software/containers/ubi9/go-toolset/61e5c00b4ec9945c18787690
-FROM registry.access.redhat.com/ubi9/go-toolset:1.22.5-1731639025@sha256:c7bfd2501cb1be171366434a368db669b32f08a0198c1473b9bff0a379613fc3 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24-1762373805 as builder
 LABEL todo-backend=builder
 # https://developers.redhat.com/articles/2022/05/31/your-go-application-fips-compliant
 ENV OPENSSL_FORCE_FIPS_MODE=1
@@ -15,7 +15,7 @@ RUN make get-deps build
 
 
 # https://catalog.redhat.com/software/containers/ubi9-minimal/61832888c0d15aff4912fe0d
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4-949.1714662671@sha256:2636170dc55a0931d013014a72ae26c0c2521d4b61a28354b3e2e5369fa335a3
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1760515502
 LABEL todo-backend=backend
 # https://developers.redhat.com/articles/2022/05/31/your-go-application-fips-compliant
 ENV OPENSSL_FORCE_FIPS_MODE=1

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ module github.com/avisiedo/go-microservice-1
 //  .golangci.yaml
 //    => linters-settings.gofumpt.lang-version
 //    => run.go
-go 1.23.7
+go 1.24.0
 
 toolchain go1.24.6
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -5,7 +5,7 @@ module github.com/avisiedo/go-microservice-1/tools
 // When updating go version, update the below too:
 //   .github/workflows/main.yml
 //   build/package/Dockerfile
-go 1.23.7
+go 1.24.0
 
 toolchain go1.24.6
 


### PR DESCRIPTION
- Update go.mod and tools/go.mod to require golang 1.24.0
- Update pipeline to use golang 1.24.0
- Update Dockerfile to use golang 1.24.0 (the sha256 hash seems to be related with the platform architecture, and it was avoiding to build in arm architectures).