### PR TITLE
bump: golang 1.24.0

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -70,7 +70,7 @@ run:
   # Define the Go version limit.
   # Mainly related to generics support since go1.18.
   # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.18
-  go: '1.22'
+  go: '1.24'
 
 # output configuration options
 output:

--- a/internal/infrastructure/logger/gorm_log_test.go
+++ b/internal/infrastructure/logger/gorm_log_test.go
@@ -131,35 +131,35 @@ func TestLogCommon(t *testing.T) {
 func TestLogMsg(t *testing.T) {
 	testCases := helperCommonTestCase(LevelDebug)
 	testCommon(t, testCases, func(l *gormLogger, level slog.Level, msg string) {
-		l.logMsg(context.Background(), level, msg)
+		l.logMsg(context.Background(), level, "%s", msg)
 	})
 }
 
 func TestLog(t *testing.T) {
 	testCases := helperCommonTestCase(LevelDebug)
 	testCommon(t, testCases, func(l *gormLogger, level slog.Level, msg string) {
-		l.log(context.Background(), level, msg)
+		l.log(context.Background(), level, "%s", msg)
 	})
 }
 
 func TestInfo(t *testing.T) {
 	testCases := helperCommonTestCase(LevelInfo)
 	testCommonSpecific(t, testCases, func(l *gormLogger, msg string) {
-		l.Info(context.Background(), msg)
+		l.Info(context.Background(), "%s", msg)
 	})
 }
 
 func TestWarn(t *testing.T) {
 	testCases := helperCommonTestCase(LevelWarn)
 	testCommonSpecific(t, testCases, func(l *gormLogger, msg string) {
-		l.Warn(context.Background(), msg)
+		l.Warn(context.Background(), "%s", msg)
 	})
 }
 
 func TestError(t *testing.T) {
 	testCases := helperCommonTestCase(LevelError)
 	testCommonSpecific(t, testCases, func(l *gormLogger, msg string) {
-		l.Error(context.Background(), msg)
+		l.Error(context.Background(), "%s", msg)
 	})
 }
 

--- a/internal/usecase/presenter/sync/echo/todo_presenter_input.go
+++ b/internal/usecase/presenter/sync/echo/todo_presenter_input.go
@@ -49,7 +49,7 @@ func (i *todoInput) Create(ctx echo.Context) (*model.Todo, error) {
 // GetAll input adapter for GetAll operation
 func (i *todoInput) GetAll(ctx echo.Context) error {
 	if len(ctx.QueryParams()) > 0 {
-		return fmt.Errorf("No query parameters expected for " + ctx.Path())
+		return fmt.Errorf("No query parameters expected for %s", ctx.Path())
 	}
 	return nil
 }

--- a/scripts/mk/go-rules.mk
+++ b/scripts/mk/go-rules.mk
@@ -4,7 +4,7 @@
 # the generated binaries.
 ##
 
-GOVERSION := 1.23.7
+GOVERSION := 1.24.0
 export GOVERSION
 
 GOSUMDB := sum.golang.org


### PR DESCRIPTION
- Update GOVERSION at scripts/mk/go-rules.mk to use golang 1.24.0
