### PR TITLE
fix: disable generate diagrams

### DIFF
--- a/scripts/mk/go-rules.mk
+++ b/scripts/mk/go-rules.mk
@@ -53,8 +53,8 @@ build-all: $(BIN) ## Generate code and build binaries
 	$(MAKE) generate-api
 	# $(MAKE) generate-event
 	$(MAKE) generate-mock
-	$(MAKE) generate-diagrams
 	$(MAKE) build
+	# $(MAKE) generate-diagrams
 
 # Meta rule to add dependency on the binaries generated
 .PHONY: build


### PR DESCRIPTION
During the execution in toolbox, it was observed that:
- generate-diagrams require the database up and initialized.
- to initialize the database the cmd/db-tool is required, so it require to build first.

So, it is changed the order, but even changing the order there is an issue because in toolbox, we cannot run another container, so it is finally disabled from 'build-all' rule.

It can be invoked by hand by 'make generate-diagrams'.