### PR TITLE
fix: cov report on pull request

### DIFF
--- a/.github/workflows/main-single.yml
+++ b/.github/workflows/main-single.yml
@@ -5,7 +5,7 @@ name: Continuous Integration
 
 on:
   # - push
-  - pull_request
+  - pull_request_target
 
 jobs:
   ci:
@@ -78,7 +78,6 @@ jobs:
 
       - name: "Add Coverage PR Comment"
         uses: marocchino/sticky-pull-request-comment@v2
-        if: github.event_name == 'pull_request'
         with:
           recreate: true
           path: code-coverage-results.md


### PR DESCRIPTION
Change the event from pull_request to pull_request_target

This means the workflow only is executed on the target PR, not in the source PR. So this workflow only will run on the target, not in source nor on push as only pull_request_target event is indicated.