### PR TITLE
feat: integrate stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,29 @@
+# https://github.com/actions/stale
+---
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          stale-issue-message: >
+            This issue is stale because it has been open 30 days with no
+            activity. Remove stale label or comment, or this will be closed
+            in 5 days.
+          stale-pr-message: >
+            This PR is stale because it has been open 45 days with no activity.
+            Remove stale label or comment, or this will be closed in 10 days.
+          stale-issue-label: 'no-issue-activity'
+          exempt-issue-labels: 'awaiting-approval,work-in-progress'
+          stale-pr-label: 'no-pr-activity'
+          exempt-pr-labels: 'awaiting-approval,work-in-progress'
+          only-labels: 'awaiting-feedback,awaiting-answers'
+          days-before-issue-stale: 30
+          days-before-pr-stale: 45
+          days-before-issue-close: 5
+          days-before-pr-close: 10


### PR DESCRIPTION
Integrate stale bot allow to automatically do housekeeping when some issue or pr stay open for a while, letting to reduce the scope and focus of the repository workflow.