### PR TITLE
fix: workflow dows not contain permissions

### DIFF
--- a/.github/workflows/main-single.yml
+++ b/.github/workflows/main-single.yml
@@ -7,6 +7,10 @@ on:
   # - push
   - pull_request
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   ci:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
As per CodeQL: Actions job or workflow does not limit the permissions of the GITHUB_TOKEN. Consider setting an explicit permissions block, using the following as a minimal starting point: {contents: read}