### PR TITLE
fix: workflow stale does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,7 +3,12 @@
 name: 'Close stale issues and PRs'
 on:
   schedule:
-    - cron: '30 1 * * *'
+    # - cron: '30 1 * * *'
+    - cron: '0 18 * * *'
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   stale:


### PR DESCRIPTION
As CodeQL say:  Actions job or workflow does not limit the permissions of the GITHUB_TOKEN. Consider setting an explicit permissions block, using the following as a minimal starting point: {contents: write, issues: write, pull-requests: write}

Add a more restrictive recommendation, and update the schedule to run daily to finetune the changes on this PR.